### PR TITLE
standardize EOL for java files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java whitespace=cr-at-eol


### PR DESCRIPTION
This change resolves ^M from showing up in diffs while editing on different platforms.