### PR TITLE
Override equals and hashcode all BTO with apache commons reflection helpers

### DIFF
--- a/docusign-restclient-dto/src/main/java/uk/co/techblue/docusign/client/dto/BaseDto.java
+++ b/docusign-restclient-dto/src/main/java/uk/co/techblue/docusign/client/dto/BaseDto.java
@@ -17,6 +17,8 @@ package uk.co.techblue.docusign.client.dto;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
@@ -37,5 +39,15 @@ public class BaseDto  implements Serializable {
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this,
 				ToStringStyle.SHORT_PREFIX_STYLE);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return EqualsBuilder.reflectionEquals(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
 	}
 }


### PR DESCRIPTION
Figured it was ok to use the reflection builders since toString() was already using one.

With out an overridden equals() method it can be very challenging to do mocking and this change is the quickest and easiest way to accomplish it. The exact use case I was running into was trying to verify the right RecipientCollection was sent. Mockito provides a reflection equals matcher but it only goes one level deep, so for example when it goes to compare if the two lists of signers inside the collection are equal it just calls equals() on the list of signers which in turn calls equals on the Signer class. This uses the equals from Object which is simple identity and returns false.

This change will give equals and hashcode implementations to all BTO objects.